### PR TITLE
feat: tokenService for logout and update JWTFilter

### DIFF
--- a/src/main/java/com/luxevision/backend/configuration/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/luxevision/backend/configuration/security/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package com.luxevision.backend.configuration.security.filter;
+import com.luxevision.backend.service.TokenService;
 import com.luxevision.backend.service.auth.JwtService;
 import com.luxevision.backend.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,6 +20,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserService userService;
+    @Autowired
+    private TokenService tokenService;
 
     public JwtAuthenticationFilter(JwtService jwtService, UserService userService) {
         this.jwtService = jwtService;
@@ -38,6 +42,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
+        }
+        if (token != null && tokenService.isTokenRevoked(token)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token has been revoked");
+            return;
         }
         chain.doFilter(request, response);
     }

--- a/src/main/java/com/luxevision/backend/controller/UserController.java~
+++ b/src/main/java/com/luxevision/backend/controller/UserController.java~
@@ -5,7 +5,6 @@ import com.luxevision.backend.dto.auth.*;
 import com.luxevision.backend.exception.InvalidPasswordException;
 import com.luxevision.backend.exception.NoChangesMadeException;
 import com.luxevision.backend.exception.UserEmailAlreadyRegisteredException;
-import com.luxevision.backend.service.TokenService;
 import com.luxevision.backend.service.auth.JwtService;
 import com.luxevision.backend.dto.ApiError;
 import com.luxevision.backend.dto.RegisteredUser;

--- a/src/main/java/com/luxevision/backend/service/TokenService.java
+++ b/src/main/java/com/luxevision/backend/service/TokenService.java
@@ -1,0 +1,19 @@
+package com.luxevision.backend.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class TokenService {
+    private final Set<String> revokedTokens = new HashSet<>();
+
+    public void revokeToken(String token) {
+        revokedTokens.add(token);
+    }
+
+    public boolean isTokenRevoked(String token) {
+        return revokedTokens.contains(token);
+    }
+}


### PR DESCRIPTION
This pull request implements a new logout functionality to enhance user session management by allowing users to securely terminate their sessions.

POST /users/logout
Invalidates the current JWT token, effectively logging the user out. The token is checked and marked as revoked to prevent further usage.

Added a TokenService to handle token revocation logic.

Updated JwtAuthenticationFilter to check if tokens are revoked before allowing access to resources.

Included necessary error handling for invalid or missing tokens.